### PR TITLE
Adding Default VS Code Workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ yarn-error.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj

--- a/.vscode/default_weather.code-workspace
+++ b/.vscode/default_weather.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "../"
+		}
+	],
+	"settings": {
+		"editor.codeActionsOnSave": {
+			"source.fixAll.eslint": true
+		},
+		"files.eol": "\n"
+	}
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "octref.vetur"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "octref.vetur"
+        "octref.vetur",
+        "eamodio.gitlens"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A VueJS Weather App
 [![Join the chat at https://gitter.im/skill-collectors/weather-app](https://badges.gitter.im/skill-collectors/weather-app.svg)](https://gitter.im/skill-collectors/weather-app?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Project setup
+If you're using VS Code, open default_weather.code-workspace from the .vscode folder as a workspace. This will provide a consistent settings and extention experience. 
+
 ```
 npm install
 ```


### PR DESCRIPTION
Closes #7 

Adding a Default VS Code Workspace to standardize some frequently used settings and extensions. 

Added the following recommended extensions:
- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint): IDE plugin for ESLint
- [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur): Extended Vue Toolkit
- [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens): Enhanced Git controls