### PR TITLE
Deploy script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24961,6 +24961,15 @@
         "escape-goat": "^2.0.0"
       }
     },
+    "push-dir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/push-dir/-/push-dir-0.4.1.tgz",
+      "integrity": "sha1-KUgerNnCEGu7eUHbbTfRIqBx7LQ=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:e2e": "codeceptjs run",
     "lint": "vue-cli-service lint",
     "build-storybook": "build-storybook",
-    "storybook": "start-storybook -p 6006"
+    "storybook": "start-storybook -p 6006",
+    "deploy": "npm run build; push-dir --dir=dist --branch=gh-pages --cleanup"
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
@@ -55,6 +56,7 @@
     "playwright": "^1.5.2",
     "popper.js": "^1.16.0",
     "portal-vue": "^2.1.7",
+    "push-dir": "^0.4.1",
     "react-is": "^16.13.1",
     "sass": "^1.29.0",
     "sass-loader": "^10.0.5",

--- a/src/services/openWeatherMap.ts
+++ b/src/services/openWeatherMap.ts
@@ -36,7 +36,6 @@ export default class OpenWeatherMap {
       output = await response.json();
     } catch (error) {
       output = error;
-      console.log(JSON.stringify(error));
     }
     await countapi.hit(process.env.VUE_APP_COUNTER_NAME, 'forecast-weather')
       .then((result: { value: number; }) => { this.callCountForecast = result.value; });
@@ -60,7 +59,6 @@ export default class OpenWeatherMap {
       output = await response.json();
     } catch (error) {
       output = error;
-      console.log(JSON.stringify(error));
     }
     await countapi.hit(process.env.VUE_APP_COUNTER_NAME, 'forecast-weather')
       .then((result: { value: number; }) => { this.callCountForecast = result.value; });
@@ -82,7 +80,6 @@ export default class OpenWeatherMap {
       output = await response.json();
     } catch (error) {
       output = error;
-      console.log(JSON.stringify(error));
     }
     await countapi.hit(process.env.VUE_APP_COUNTER_NAME, 'current-weather')
       .then((result: { value: number; }) => { this.callCountCurrent = result.value; });
@@ -105,7 +102,6 @@ export default class OpenWeatherMap {
       output = await response.json();
     } catch (error) {
       output = error;
-      console.log(JSON.stringify(error));
     }
     await countapi.hit(process.env.VUE_APP_COUNTER_NAME, 'current-weather')
       .then((result: { value: number; }) => { this.callCountCurrent = result.value; });
@@ -129,7 +125,6 @@ export default class OpenWeatherMap {
       output = await response.json();
     } catch (error) {
       output = error;
-      console.log(JSON.stringify(error));
     }
     await countapi.hit(process.env.VUE_APP_COUNTER_NAME, 'one-weather')
       .then((result: { value: number; }) => { this.callCountCurrent = result.value; });

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  publicPath: process.env.NODE_ENV === 'production'
+    ? '/weather-app/'
+    : '/',
+};


### PR DESCRIPTION
This adds an `npm run deploy` task that builds the app and pushes the build output (`dist` directory) to the gh-pages branch, which publishes it at https://skill-collectors.github.io/weather-app/ (check it out!)

Some future steps that are not in this PR (progress over perfection):
- Update the app to allow a user-supplied OpenWeather key (it's currently using my key)
- Create a new GitHub action to run the deploy after a PR merges into master
- Restrict arbitrary deploys by locking down the gh-pages branch so only GitHub Actions can push to it

This PR is not intended to stop any work happening to get the app deployed to Amazon S3 and Cloudfront. It's just an idea I had that I wanted to try. In fact, I think that work is still especially important if we want to get deploys from PRs before they are merged.