### PR TITLE
Remove 'git add' from lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
   },
   "lint-staged": {
     "*.{js,vue,ts}": [
-      "vue-cli-service lint",
-      "git add"
+      "vue-cli-service lint"
     ]
   }
 }


### PR DESCRIPTION
The 'git add' line caused a warning in the console saying it's not needed. I removed it and tested by making a commit with bad formatting, and the content of the commit was linted.

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
~~The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).~~ There is no change to the build output.

