### PR TITLE
Auto-reload in service worker 'updated' hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -19,8 +19,11 @@ if (process.env.NODE_ENV === 'production') {
     updatefound() {
       console.log('New content is downloading.');
     },
-    updated() {
+    updated(registration) {
       console.log('New content is available; please refresh.');
+      // Just immediately refresh. In the future we can add UI to prompt the user to refresh.
+      registration?.waiting?.postMessage({ type: 'SKIP_WAITING' });
+      window.location.reload();
     },
     offline() {
       console.log('No internet connection found. App is running in offline mode.');


### PR DESCRIPTION
This commit allows the app to load new versions of the application (when available) instead of relying on the cached version forever.

I'm just having the app reload immediately. This could result in the user getting interrupted if e.g. they are in the middle of typing
something. We can improve this later by e.g. adding a button to the UI and asking the user to press it to refresh.

Note that we cannot ask the user to "click the reload button" because if they have this site installed as an app, the browser controls won't be visible.

This is a (very) simplified version of what's described here: https://dev.to/drbragg/handling-service-worker-updates-in-your-vue-pwa-1pip

See https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps for more info on Progressive Web Apps (PWAs).

Testing
-------

The service worker does not get registered in non-production deploys. If you want to test this locally, you need to:

1. npm install -g http-server
2. Edit (temporarily!) vue.config.js to serve from '/' in production.
3. npm run build && http-server dist/

Then you will have a production build at localhost:8080 that will use the service worker. After loading the page, you can stop your server, refresh the browser, and see that the app loads as if nothing is wrong. You can then make an arbitrary change, then re-run
`npm run build && npm run serve dist/`. The next time you go to the page, it will load from the cache, then reload with the updated content. Prior to this commit, you'd never see the update without a hard (ctrl-shift-r) reload.

It's recommended you use a private browsing tab so the PWA cache doesn't get in the way when you go back to normal
development.

Closes #65 

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).
