### PR TITLE
Always use https URLs for OpenWeather

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/services/openWeatherService.ts
+++ b/src/services/openWeatherService.ts
@@ -98,11 +98,11 @@ export default {
   },
 
   iconToUrl(icon: string): string {
-    return `http://openweathermap.org/img/wn/${icon}.png`;
+    return `https://openweathermap.org/img/wn/${icon}.png`;
   },
 
   async searchCoordsByCity(query: string): Promise<GeoDirectResponse[]> {
-    const url = `http://api.openweathermap.org/geo/1.0/direct?&q=${query}&appId=${store.state.apiKeys[OPEN_WEATHER]!}`;
+    const url = `https://api.openweathermap.org/geo/1.0/direct?&q=${query}&appId=${store.state.apiKeys[OPEN_WEATHER]!}`;
     const response = await fetch(url);
     // TODO add call to count API, but should we track different endpoint calls separately?
     return await response.json() as GeoDirectResponse[];

--- a/src/views/OpenWeatherAPIPage.vue
+++ b/src/views/OpenWeatherAPIPage.vue
@@ -41,7 +41,7 @@
               <h5 style='align-self:center'>
                 {{ list.weather[0].description.charAt(0).toUpperCase()
                   + list.weather[0].description.slice(1)}}</h5>
-              <img :src="'http://openweathermap.org/img/wn/'+ list.weather[0].icon + '@2x.png'" alt="">
+              <img :src="'https://openweathermap.org/img/wn/'+ list.weather[0].icon + '@2x.png'" alt="">
             </div>
           </b-list-group-item>
           <p>Low: {{list.main.temp_min }} °F


### PR DESCRIPTION
This PR replaces `http://` with `https://` for all OpenWeather URLs in production code. This is needed to fix the app in production.

Closes #208

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

