### PR TITLE
Add coming up service unit tests

### DIFF
--- a/src/services/ComingUpService.ts
+++ b/src/services/ComingUpService.ts
@@ -24,7 +24,10 @@ function getUpcomingRainNotification(weather: OneCallWeather): ComingUpNotificat
 
 function getSnowTonightNotification(weather: OneCallWeather): ComingUpNotification | undefined {
   const maybeSnowTonight = weather.hourly
-    .filter((forecast) => differenceInHours(convert.dtToDate(forecast.dt), new Date()) < 24)
+    .filter((forecast) => differenceInHours(
+      // Date.now() is easier to mock in unit tests than the no-arg Date constructor.
+      convert.dtToDate(forecast.dt), new Date(Date.now()),
+    ) < 24)
     .filter((forecast) => getHours(forecast.dt) > 20 || getHours(forecast.dt) < 8)
     .find((forecast) => forecast.weather[0].main === 'Snow');
   if (maybeSnowTonight !== undefined) {

--- a/tests/unit/services/ComingUpService.spec.ts
+++ b/tests/unit/services/ComingUpService.spec.ts
@@ -1,0 +1,99 @@
+import determineComingUpNotifications from '@/services/ComingUpService';
+import { OneCallWeather } from '@/store/types';
+
+describe('ComingUpService', () => {
+  let weather: OneCallWeather;
+
+  beforeEach(() => {
+    weather = {
+      current: {
+        temp: 0,
+        feels_like: 0,
+        weather: [{
+          description: 'sunny', icon: '03n', id: 800, main: 'Clear',
+        }],
+      },
+      minutely: [{ dt: 0, precipitation: 0 }],
+      hourly: [{
+        dt: 0,
+        temp: 0,
+        feels_like: 0,
+        weather: [{
+          description: '', icon: '', id: 0, main: '',
+        }],
+      }],
+      daily: [{
+        dt: 0,
+        temp: {
+          day: 0, eve: 0, morn: 0, night: 0, min: 0, max: 0,
+        },
+        feels_like: {
+          day: 0, eve: 0, morn: 0, night: 0,
+        },
+        weather: [{
+          description: '', icon: '', id: 0, main: '',
+        }],
+      }],
+    };
+  });
+
+  it('finds nothing when the weather is clear', () => {
+    // Given
+    weather.hourly = [{
+      dt: new Date().getTime(),
+      temp: 72,
+      feels_like: 71,
+      weather: [{
+        description: 'clear sky', icon: '01d', id: 0, main: 'clear sky',
+      }],
+    }];
+
+    // When
+    const result = determineComingUpNotifications(weather);
+
+    // Then
+    expect(result).toHaveLength(0);
+  });
+
+  it('finds rain in the next hour', () => {
+    // Given
+    const oneHourFromNowDt = (Date.now() / 1000) + 3_600;
+
+    weather.hourly = [{
+      dt: oneHourFromNowDt,
+      temp: 72,
+      feels_like: 71,
+      weather: [{
+        description: 'rain', icon: '10d', id: 0, main: 'Rain',
+      }],
+    }];
+
+    // When
+    const result = determineComingUpNotifications(weather);
+
+    // Then
+    expect(result).toHaveLength(1);
+  });
+
+  it('finds snow overnight', () => {
+    // Given
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() => new Date('2020-02-21T19:01:58.135Z').valueOf());
+
+    weather.hourly = [{
+      dt: new Date('2020-02-22T06:00:00.00Z').getTime() / 1000,
+      temp: 72,
+      feels_like: 71,
+      weather: [{
+        description: 'snow', icon: '13n', id: 0, main: 'Snow',
+      }],
+    }];
+
+    // When
+    const result = determineComingUpNotifications(weather);
+
+    // Then
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the ComingUpService

Note: I had to update the production code to get the time via `new Date(Date.now())` instead of just `new Date()` because I couldn't figure out a way to cleanly mock the `Date` constructor. All the implementations I found online made Typescript upset. Normally I don't like bending production code to suit tests, but I'm giving up on it for now. Feel free to push any better solutions if you can figure it out.

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

