### PR TITLE
Refresh on focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
This PR lets the app auto-refresh. Previously, the data would only load when you first open the app or change your location. This was not perfect because when the app is "installed" on mobile or you just leave the tab open it doesn't always refresh when you switch back to it.

With this PR, the auto-refresh basically works like this:
- When you switch to the app (e.g. click on the tab in a browser) it reloads if the last reload was > 15 minutes ago
- As long as the app has focus, it reloads once every hour

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

