### PR TITLE
Allow horizontal scrolling of forecast lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/DailyForecast.vue
+++ b/src/components/DailyForecast.vue
@@ -30,7 +30,7 @@ export default class DailyForecast extends Vue {
   $store!: Store<RootState>
 
   get days() {
-    return this.$store.state.weather.daily.slice(0, 5);
+    return this.$store.state.weather.daily;
   }
 }
 </script>
@@ -39,7 +39,15 @@ ul {
   list-style-type: none;
   padding-left: 0;
   margin-bottom: 0;
-  display: flex;
-  justify-content: space-between;
+  width: 100%;
+  overflow-x: scroll;
+  scrollbar-width: none; /* Firefox */
+}
+ul::-webkit-scrollbar {
+  display: none; /* Webkit */
+}
+li {
+  display: inline-block;
+  width: 20%;
 }
 </style>

--- a/src/components/HourlyForecast.vue
+++ b/src/components/HourlyForecast.vue
@@ -29,7 +29,7 @@ export default class HourlyForecast extends Vue {
   $store!: Store<RootState>
 
   get hours() {
-    return this.$store.state.weather.hourly.slice(0, 5);
+    return this.$store.state.weather.hourly;
   }
 }
 </script>
@@ -38,7 +38,15 @@ ul {
   list-style-type: none;
   padding-left: 0;
   margin-bottom: 0;
-  display: flex;
-  justify-content: space-between;
+  width: 100%;
+  overflow-x: scroll;
+  scrollbar-width: none; /* Firefox */
+}
+ul::-webkit-scrollbar {
+  display: none; /* Webkit */
+}
+li {
+  display: inline-block;
+  width: 20%;
 }
 </style>


### PR DESCRIPTION
This PR allows the user to scroll horizontally to reveal more forecast items in the hourly and daily lists.

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

