### PR TITLE
Clarify how we use Semantic Versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,22 @@ When you are ready, request a review from either a specific person/people or fro
 
 Requesting approval assumes that the PR can be merged by the approver once approved. If you want someone to look at your PR, but you aren't ready for it to be merged, create a [draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) and then `@mention` someone in the comments to get their opinion.
 
+## Versioning
+
+This application uses [Semver](https://semver.org/) as a versioning strategy, but it's admittedly not obvious how to apply that to an application rather than a library. Here's our take:
+
+Given a version number `[MAJOR].[MINOR].[PATCH]`, we
+
+- Increment the **PATCH** number for changes that are not visible in the user interface. For example:
+	- Dependency updates
+	- Bug fixes in the implementation
+	- Refactoring without any functional change
+- Increment the **MINOR** number for changes that are visible in the user interface. For example:
+	- CSS and other layout changes
+	- Text changes (even minor ones including typo fixes)
+	- A new UXP component (e.g. new button).
+- Increment the **MAJOR** number for major architectural changes. Examples may include:
+	- Building and packaging as a mobile app (i.e. an actual apk file for Android)
+	- Upgrading from Vue 2 to Vue 3
+	- Replacing bootstrap-vue with a different UI framework
+


### PR DESCRIPTION
This PR clarifies how to apply Semantic Versioning rules to this application, but *I am okay not merging this!*

I think this is a good clarification *if* we want to stick with Semantic Versioning, but I'm open to the idea that it doesn't make sense in this context. The real question is: what do we want to *communicate* with our version number?

**I'm giving this more thought, so this is a draft PR.** Below are my thoughts at the moment, but they aren't complete and I'll add more later.

SemVer is meant to communicate whether this version will break your app if you pull it in as a dependency. This app is not a dependency, so it doesn't really fit that model.

In an app, you want the version number to communicate things like the following:
1. What version is a user using. Okay, this is kind of axiomatic, but the point is that if someone reports a bug, it helps to know what version the bug is in or not in.
2. Whether a version is a regular release or a pre-release. That is, is it delivered to users, a release candidate for pilot users, an automated nightly build?
3. Distinguish between fundamentally different forms of the app. Like if you completely rewrite it, you want to call out a whole different release train especially if you're going to offer long term support/bug fixes to the prior version of the app.

## Checklist before requesting approval

- [ ] All PR checks succeed
- [ ] This branch does not have any conflicts with the master branch.
- [ ] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

