### PR TITLE
Detect when it will stop raining

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weather-app",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/services/ComingUpService.ts
+++ b/src/services/ComingUpService.ts
@@ -9,6 +9,10 @@ export interface ComingUpNotification {
 }
 
 function getUpcomingRainNotification(weather: OneCallWeather): ComingUpNotification | undefined {
+  if (weather.current.weather[0].main === 'Rain') {
+    // It's already raining, so don't tell the user it's going to start
+    return undefined;
+  }
   const maybeRainy = weather.hourly
     .filter((forecast) => differenceInHours(convert.dtToDate(forecast.dt), new Date()) < 12)
     .find((forecast) => forecast.weather[0].main === 'Rain');
@@ -16,10 +20,31 @@ function getUpcomingRainNotification(weather: OneCallWeather): ComingUpNotificat
     return {
       type: 'RAIN',
       iconUrl: convert.iconToUrl(maybeRainy.weather[0].icon),
-      text: `${maybeRainy.weather[0].description} coming up at ${format(convert.dtToDate(maybeRainy.dt), 'ha')}`,
+      text: `${maybeRainy.weather[0].description} will start at ${format(convert.dtToDate(maybeRainy.dt), 'ha')}`,
     };
   }
   return undefined;
+}
+
+function getRainStoppingNotification(weather: OneCallWeather): ComingUpNotification | undefined {
+  if (weather.current.weather[0].main !== 'Rain') {
+    // It's not raining, so don't notify when it will stop
+    return undefined;
+  }
+  const maybeNotRainy = weather.hourly
+    .find((forecast) => forecast.weather[0].main !== 'Rain');
+  if (maybeNotRainy === undefined) {
+    return {
+      type: 'STOP_RAIN',
+      iconUrl: convert.iconToUrl(weather.current.weather[0].icon),
+      text: "It's going to rain all day.",
+    };
+  }
+  return {
+    type: 'STOP_RAIN',
+    iconUrl: convert.iconToUrl(maybeNotRainy.weather[0].icon),
+    text: `${weather.current.weather[0].description} will stop at ${format(convert.dtToDate(maybeNotRainy.dt), 'ha')}`,
+  };
 }
 
 function getSnowTonightNotification(weather: OneCallWeather): ComingUpNotification | undefined {
@@ -53,6 +78,7 @@ determineComingUpNotifications(weather: OneCallWeather): ComingUpNotification[] 
   const results: ComingUpNotification[] = [];
 
   pushIfPresent(results, getUpcomingRainNotification(weather));
+  pushIfPresent(results, getRainStoppingNotification(weather));
   pushIfPresent(results, getSnowTonightNotification(weather));
 
   return results;

--- a/tests/unit/services/ComingUpService.spec.ts
+++ b/tests/unit/services/ComingUpService.spec.ts
@@ -75,6 +75,70 @@ describe('ComingUpService', () => {
     expect(result).toHaveLength(1);
   });
 
+  it("does not find upcoming rain if it's already raining", () => {
+    // Given
+    const oneHourFromNowDt = (Date.now() / 1000) + 3_600;
+
+    weather.current = {
+      temp: 0,
+      feels_like: 0,
+      weather: [{
+        description: 'light rain', icon: '10d', id: 0, main: 'Rain',
+      }],
+    };
+    weather.hourly = [{
+      dt: oneHourFromNowDt,
+      temp: 72,
+      feels_like: 71,
+      weather: [{
+        description: 'rain', icon: '10d', id: 0, main: 'Rain',
+      }],
+    }];
+
+    // When
+    const result = determineComingUpNotifications(weather);
+
+    // Then
+    expect(result.find((note) => note.type === 'RAIN')).toBeUndefined();
+  });
+
+  it("finds when rain will stop if it's already raining", () => {
+    // Given
+    const oneHourFromNowDt = (Date.now() / 1000) + 3_600;
+
+    weather.current = {
+      temp: 0,
+      feels_like: 0,
+      weather: [{
+        description: 'light rain', icon: '10d', id: 0, main: 'Rain',
+      }],
+    };
+    weather.hourly = [
+      {
+        dt: oneHourFromNowDt,
+        temp: 72,
+        feels_like: 71,
+        weather: [{
+          description: 'rain', icon: '10d', id: 0, main: 'Rain',
+        }],
+      },
+      {
+        dt: oneHourFromNowDt + 3_600,
+        temp: 72,
+        feels_like: 71,
+        weather: [{
+          description: 'clear', icon: '01d', id: 0, main: 'Clear',
+        }],
+      },
+    ];
+
+    // When
+    const result = determineComingUpNotifications(weather);
+
+    // Then
+    expect(result.find((note) => note.type === 'STOP_RAIN')).not.toBeUndefined();
+  });
+
   it('finds snow overnight', () => {
     // Given
     jest


### PR DESCRIPTION
This PR adds a "coming up" notification to indicate when rain will stop.

In a future PR, we can update this to take the "minutely" weather into account to look at rain starting or stopping within the next hour.

## Checklist before requesting approval

- [x] All PR checks succeed
- [x] This branch does not have any conflicts with the master branch.
- [x] The version number has been incremented appropriately (we use [Semver](https://semver.org/) as a versioning strategy).

